### PR TITLE
Fix/59 fix sidebar links to creation

### DIFF
--- a/src/app/components/LoginForm.jsx
+++ b/src/app/components/LoginForm.jsx
@@ -15,6 +15,10 @@ function LoginForm() {
 
 	const router = useRouter()
 
+	const isMobile = () => {
+		return window.innerWidth <= 768
+	}
+
 	async function onSubmit(event) {
 		event.preventDefault()
 		const formData = new FormData(event.target)
@@ -24,7 +28,9 @@ function LoginForm() {
 			.then(function (response) {
 				document.cookie = `access_token=${response.data.access_token}; Secure; HttpOnly; SameSite=Strict`
 				document.cookie = `refresh_token=${response.data.refresh_token}; Secure; HttpOnly; SameSite=Strict`
-				router.push('/families')
+				const stateSidebar = isMobile() ? 'false' : 'true'
+				console.log(stateSidebar)
+				router.push(`/families?showSidebar=${stateSidebar}`)
 			})
 			.catch(function (error) {
 				alert('Error al iniciar sesión: ' + error.response.data.detail)

--- a/src/app/components/LoginForm.jsx
+++ b/src/app/components/LoginForm.jsx
@@ -16,7 +16,7 @@ function LoginForm() {
 	const router = useRouter()
 
 	const isMobile = () => {
-		return window.innerWidth <= 768
+		return typeof window !== 'undefined' ? window.innerWidth <= 768 : false
 	}
 
 	async function onSubmit(event) {
@@ -29,7 +29,6 @@ function LoginForm() {
 				document.cookie = `access_token=${response.data.access_token}; Secure; HttpOnly; SameSite=Strict`
 				document.cookie = `refresh_token=${response.data.refresh_token}; Secure; HttpOnly; SameSite=Strict`
 				const stateSidebar = isMobile() ? 'false' : 'true'
-				console.log(stateSidebar)
 				router.push(`/families?showSidebar=${stateSidebar}`)
 			})
 			.catch(function (error) {

--- a/src/app/components/sidebar.jsx
+++ b/src/app/components/sidebar.jsx
@@ -13,7 +13,7 @@ export default function Sidebar() {
 	const { replace } = useRouter()
 
 	const isMobile = () => {
-		return window.innerWidth <= 768
+		return typeof window !== 'undefined' ? window.innerWidth <= 768 : false
 	}
 
 	const initialState = isMobile() ? 'false' : 'true'

--- a/src/app/components/sidebar.jsx
+++ b/src/app/components/sidebar.jsx
@@ -2,7 +2,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 /* eslint-disable no-unused-vars */
-import React from 'react'
+import React, { useEffect } from 'react'
 /* eslint-enable no-unused-vars */
 import { useSearchParams, usePathname, useRouter } from 'next/navigation'
 import SidebarEntry from './sidebarEntry'
@@ -12,17 +12,17 @@ export default function Sidebar() {
 	const pathname = usePathname()
 	const { replace } = useRouter()
 
+	const isMobile = () => {
+		return window.innerWidth <= 768
+	}
+
+	const initialState = isMobile() ? 'false' : 'true'
+
 	const links = [
 		{
-			link: '/families',
+			link: `/families?showSidebar=${initialState}`,
 			icon: '/family.svg',
 			text: 'Familias'
-		},
-		{
-			link: '/families?show=true',
-			icon: '/square-plus.svg',
-			text: 'Dar de alta',
-			subentry: true
 		},
 		{
 			link: '',
@@ -31,15 +31,9 @@ export default function Sidebar() {
 			subentry: true
 		},
 		{
-			link: '/food',
+			link: `/food?showSidebar=${initialState}`,
 			icon: '/box.svg',
 			text: 'Inventario'
-		},
-		{
-			link: '/food?showModal=true',
-			icon: '/square-plus.svg',
-			text: 'Añadir elemento',
-			subentry: true
 		},
 		{
 			link: '',
@@ -63,7 +57,7 @@ export default function Sidebar() {
 			text: 'Usuarios'
 		},
 		{
-			link: '/create-user',
+			link: `/create-user?showSidebar=${initialState}`,
 			icon: '/face-plus.svg',
 			text: 'Crear nuevo usuario',
 			subentry: true

--- a/src/app/components/sidebar.jsx
+++ b/src/app/components/sidebar.jsx
@@ -2,7 +2,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 /* eslint-disable no-unused-vars */
-import React, { useEffect } from 'react'
+import React from 'react'
 /* eslint-enable no-unused-vars */
 import { useSearchParams, usePathname, useRouter } from 'next/navigation'
 import SidebarEntry from './sidebarEntry'


### PR DESCRIPTION
# Description

Delete links to modal and add function to change sidebar status depending on screen layout. When you change the screen size it is not automatically hidden or displayed but when you navigate from the sidebar to that endpoint with that screen size it will be hidden or displayed.

# How Has This Been Tested?
Testing informal.

- [x] See that the sidebar is hidden and displayed when browsing on different screen sizes.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes