### PR TITLE
feat: Add warehouse CRUD

### DIFF
--- a/src/app/components/WarehouseForm.jsx
+++ b/src/app/components/WarehouseForm.jsx
@@ -1,31 +1,73 @@
 'use client'
 /* eslint-disable no-unused-vars */
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 /* eslint-enable no-unused-vars */
 import axios from 'axios'
 
-function WarehouseForm({ onClickFunction }) {
+export default function WarehouseForm({ onClickFunction, warehouseToUpdate }) {
 	const [formData, setFormData] = useState({
 		name: '',
 		products: []
 	})
+
+	useEffect(() => {
+		if (warehouseToUpdate) {
+			console.log('warehouseToUpdate:', warehouseToUpdate)
+			setFormData(warehouseToUpdate)
+		}
+	}, [warehouseToUpdate])
 
 	const handleNewWarehouseNameChange = e => {
 		const { name, value } = e.target
 		setFormData({ ...formData, [name]: value })
 	}
 
-	const handleCreateWarehouse = () => {
-		const finalFormData = {
-			...formData
-		}
+	const handleAction = () => {
 		const BASEURL = process.env.NEXT_PUBLIC_BASE_URL
-		axios.post(`${BASEURL}/cyc/warehouse`, JSON.stringify(finalFormData), {
-			headers: {
-				'Content-Type': 'application/json'
-			}
-		})
-		console.log('Datos del formulario:', finalFormData)
+		if (warehouseToUpdate) {
+			axios
+				.put(
+					`${BASEURL}/cyc/warehouse/${warehouseToUpdate.id}`,
+					JSON.stringify(formData),
+					{
+						headers: {
+							'Content-Type': 'application/json'
+						}
+					}
+				)
+				.then(() => {
+					window.location.reload()
+				})
+				.catch(error => {
+					console.error('Error al actualizar el almacén:', error)
+					alert(
+						'Se produjo un error al actualizar el almacén. Por favor, inténtalo de nuevo.'
+					)
+				})
+		} else {
+			const finalFormData = { ...formData }
+			axios
+				.post(`${BASEURL}/cyc/warehouse`, JSON.stringify(finalFormData), {
+					headers: {
+						'Content-Type': 'application/json'
+					}
+				})
+				.then(() => {
+					window.location.reload()
+				})
+				.catch(error => {
+					console.error('Error al crear el nuevo almacén:', error)
+					if (error.response && error.response.status === 400) {
+						alert(
+							'Ya existe un almacén con ese nombre. Por favor, elige otro nombre.'
+						)
+					} else {
+						alert(
+							'Se produjo un error al crear el nuevo almacén. Por favor, inténtalo de nuevo.'
+						)
+					}
+				})
+		}
 	}
 
 	return (
@@ -58,9 +100,9 @@ function WarehouseForm({ onClickFunction }) {
 					<div className="flex justify-center w-full mt-6">
 						<button
 							className="bg-green-500 hover:bg-green-700 rounded-md drop-shadow-lg p-1 cursor-pointer text-white w-3/4 md:w-2/4 text-center"
-							onClick={handleCreateWarehouse}
+							onClick={handleAction}
 						>
-							Crear almacén
+							{warehouseToUpdate ? 'Confirmar' : 'Crear almacén'}
 						</button>
 					</div>
 				</form>
@@ -68,5 +110,3 @@ function WarehouseForm({ onClickFunction }) {
 		</div>
 	)
 }
-
-export default WarehouseForm

--- a/src/app/components/WarehouseForm.jsx
+++ b/src/app/components/WarehouseForm.jsx
@@ -81,6 +81,7 @@ export default function WarehouseForm({ onClickFunction, warehouseToUpdate }) {
 					<button
 						className="bg-red-500 text-white text-xl rounded-md shadow-lg w-[30px] h-[30px] mb-3"
 						onClick={onClickFunction}
+						data-testid="close-button"
 					>
 						X
 					</button>
@@ -105,6 +106,7 @@ export default function WarehouseForm({ onClickFunction, warehouseToUpdate }) {
 						<button
 							className="bg-green-500 hover:bg-green-700 rounded-md drop-shadow-lg p-1 cursor-pointer text-white w-3/4 md:w-2/4 text-center"
 							onClick={handleAction}
+							data-testid="create-update-button"
 						>
 							{warehouseToUpdate ? 'Confirmar' : 'Crear almacén'}
 						</button>

--- a/src/app/components/WarehouseForm.jsx
+++ b/src/app/components/WarehouseForm.jsx
@@ -1,0 +1,72 @@
+'use client'
+/* eslint-disable no-unused-vars */
+import React, { useState } from 'react'
+/* eslint-enable no-unused-vars */
+import axios from 'axios'
+
+function WarehouseForm({ onClickFunction }) {
+	const [formData, setFormData] = useState({
+		name: '',
+		products: []
+	})
+
+	const handleNewWarehouseNameChange = e => {
+		const { name, value } = e.target
+		setFormData({ ...formData, [name]: value })
+	}
+
+	const handleCreateWarehouse = () => {
+		const finalFormData = {
+			...formData
+		}
+		const BASEURL = process.env.NEXT_PUBLIC_BASE_URL
+		axios.post(`${BASEURL}/cyc/warehouse`, JSON.stringify(finalFormData), {
+			headers: {
+				'Content-Type': 'application/json'
+			}
+		})
+		console.log('Datos del formulario:', finalFormData)
+	}
+
+	return (
+		<div className="fixed bg-gray-600 bg-opacity-50 h-full w-full flex items-center justify-center z-50">
+			<div className="p-10 border h-fit shadow-lg rounded-xl bg-white">
+				<div className="flex justify-end">
+					<button
+						className="bg-red-500 text-white text-xl rounded-md shadow-lg w-[30px] h-[30px] mb-3"
+						onClick={onClickFunction}
+					>
+						X
+					</button>
+				</div>
+				<form className="flex flex-col md:flex-row md:flex-wrap justify-center max-w-[260px] gap-3 mt-2">
+					<article className="flex flex-col w-full">
+						<label htmlFor="nombre">Nombre:</label>
+
+						<input
+							data-testid="nombre"
+							type="text"
+							id="nombre"
+							name="name"
+							value={formData.name}
+							onChange={handleNewWarehouseNameChange}
+							placeholder="Almacén X"
+							className="flex items-center border-2 rounded-xl border-gray-200 bg-white p-1 pl-2 w-full"
+						/>
+					</article>
+
+					<div className="flex justify-center w-full mt-6">
+						<button
+							className="bg-green-500 hover:bg-green-700 rounded-md drop-shadow-lg p-1 cursor-pointer text-white w-3/4 md:w-2/4 text-center"
+							onClick={handleCreateWarehouse}
+						>
+							Crear almacén
+						</button>
+					</div>
+				</form>
+			</div>
+		</div>
+	)
+}
+
+export default WarehouseForm

--- a/src/app/components/WarehouseForm.jsx
+++ b/src/app/components/WarehouseForm.jsx
@@ -24,6 +24,10 @@ export default function WarehouseForm({ onClickFunction, warehouseToUpdate }) {
 
 	const handleAction = () => {
 		const BASEURL = process.env.NEXT_PUBLIC_BASE_URL
+		if (!formData.name.trim()) {
+			alert('El nombre del almacén no puede estar vacío')
+			return
+		}
 		if (warehouseToUpdate) {
 			axios
 				.put(

--- a/src/app/components/sidebar.jsx
+++ b/src/app/components/sidebar.jsx
@@ -36,6 +36,12 @@ export default function Sidebar() {
 			text: 'Inventario'
 		},
 		{
+			link: `/food/warehouse`,
+			icon: '/square-plus.svg',
+			text: 'Almacenes',
+			subentry: true
+		},
+		{
 			link: '',
 			icon: '/truck.svg',
 			text: 'Entregas'

--- a/src/app/food/warehouse/fetchDataWarehouse.js
+++ b/src/app/food/warehouse/fetchDataWarehouse.js
@@ -1,0 +1,12 @@
+import axios from 'axios'
+
+export async function fetchDataWarehouse() {
+    const BASEURL = process.env.NEXT_PUBLIC_BASE_URL
+    try	{		
+        const deliveries = await axios.get(
+            `${BASEURL}/cyc/warehouse`)
+        return deliveries.data
+    } catch (err) {
+       return null
+    }
+}

--- a/src/app/food/warehouse/page.jsx
+++ b/src/app/food/warehouse/page.jsx
@@ -1,0 +1,147 @@
+'use client'
+/* eslint-disable no-unused-vars */
+import React, { useState, Suspense, useEffect } from 'react'
+/* eslint-enable no-unused-vars */
+import Sidebar from '../../components/sidebar.jsx'
+import Searchbar from '../../components/searchbar.jsx'
+import exportData from '../../exportData.js'
+import Image from 'next/image.js'
+import axios from 'axios'
+import { fetchDataWarehouse } from './fetchDataWarehouse.js'
+import WarehouseForm from '../../components/WarehouseForm.jsx'
+
+export default function WarehouseList() {
+	const [data, setData] = useState(null)
+	const [showModal, setShowModal] = useState(false)
+
+	const handleFileChange = async event => {
+		const selectedFile = event.target.files[0]
+		try {
+			const formData = new FormData()
+			formData.append('file', selectedFile)
+			await axios.post('url/de/import', formData, {
+				headers: {
+					'Content-Type': 'multipart/form-data'
+				}
+			})
+			alert('Datos importados correctamente')
+		} catch (error) {
+			console.error(error)
+			alert('Error al importar los datos')
+		}
+	}
+
+	const toggleModal = () => {
+		setShowModal(!showModal)
+	}
+
+	const handleDeleteWarehouse = id => {
+		const confirmed = window.confirm(
+			'¿Seguro que deseas eliminar este almacén?'
+		)
+		if (confirmed) {
+			const BASEURL = process.env.NEXT_PUBLIC_BASE_URL
+			axios.delete(`${BASEURL}/cyc/warehouse/${id}`, {
+				headers: {
+					'Content-Type': 'application/json'
+				}
+			})
+			const updatedData = data.filter(warehouse => warehouse.id !== id)
+			setData(updatedData)
+		}
+	}
+
+	useEffect(() => {
+		const fetchData = async () => {
+			try {
+				const data = await fetchDataWarehouse()
+				setData(data)
+			} catch (error) {
+				console.error('Error al cargar los datos:', error)
+				alert(
+					'Se produjo un error al cargar los datos. Por favor, inténtalo de nuevo.'
+				)
+			}
+		}
+		fetchData()
+	}, [])
+
+	return (
+		<main className="flex w-full h-screen">
+			<Suspense fallback={<div></div>}>
+				<Sidebar />
+			</Suspense>
+			<div className="w-full h-full flex flex-col items-center">
+				<Searchbar handleClick={toggleModal} text="Añadir almacén" />
+				<div className="h-12 w-max flex flex-row">
+					<button
+						className=" bg-green-400 h-8 w-8 rounded-full shadow-2xl mt-3 mr-2"
+						onClick={() => exportData(data, 'Deliveries')}
+					>
+						<Image
+							src="/excel.svg"
+							className="ml-2"
+							width={15}
+							height={15}
+						></Image>
+					</button>
+					<label
+						htmlFor="file"
+						className="bg-green-400 w-32 h-6 mt-4 rounded-full font-Varela text-white cursor-pointer text-center text-sm"
+					>
+						Importar datos
+					</label>
+					<input
+						type="file"
+						id="file"
+						onChange={handleFileChange}
+						style={{ display: 'none' }}
+						accept=".xls"
+					/>
+				</div>
+				<div className="container p-10 flex flex-wrap gap-5 justify-center items-center">
+					<div className="w-full overflow-x-auto">
+						<table className="table-auto w-full">
+							<thead>
+								<tr>
+									<th className="px-4 py-2 border-b"></th>
+									<th className="px-4 py-2 border-b text-center">Nombre</th>
+									<th className="px-4 py-2 border-b text-center">Dirección</th>
+									<th className="px-4 py-2 border-b"></th>
+								</tr>
+							</thead>
+							<tbody>
+								{data &&
+									data.map((warehouse, index) => (
+										<React.Fragment key={index}>
+											<tr key={index}>
+												<td className="px-4 py-2 border-b">
+													<Image src="/box.svg" width={20} height={20} />
+												</td>
+												<td className="px-4 py-2 border-b text-center">
+													{warehouse.name}
+												</td>
+												<td className="px-4 py-2 border-b text-center">
+													{warehouse.id}
+												</td>
+												<td className="px-4 py-2 border-b">
+													<button
+														className="bg-red-500 hover:bg-red-700 rounded-md text-white font-bold py-1 px-2"
+														onClick={() => handleDeleteWarehouse(warehouse.id)}
+														type="button"
+													>
+														Eliminar
+													</button>
+												</td>
+											</tr>
+										</React.Fragment>
+									))}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+			{showModal ? <WarehouseForm onClickFunction={toggleModal} /> : null}
+		</main>
+	)
+}

--- a/src/app/food/warehouse/page.jsx
+++ b/src/app/food/warehouse/page.jsx
@@ -136,7 +136,7 @@ export default function WarehouseList() {
 								{data &&
 									data.map((warehouse, index) => (
 										<React.Fragment key={index}>
-											<tr key={index}>
+											<tr key={index} data-testid="warehouse-data">
 												<td className="px-4 py-2 border-b">
 													<Image src="/box.svg" width={20} height={20} />
 												</td>
@@ -159,6 +159,7 @@ export default function WarehouseList() {
 															handleDeleteWarehouse(warehouse.id)
 														}
 														color={'bg-red-500'}
+														data-testid="delete-button"
 													/>
 												</td>
 											</tr>

--- a/src/app/food/warehouse/page.jsx
+++ b/src/app/food/warehouse/page.jsx
@@ -106,7 +106,6 @@ export default function WarehouseList() {
 								<tr>
 									<th className="px-4 py-2 border-b"></th>
 									<th className="px-4 py-2 border-b text-center">Nombre</th>
-									<th className="px-4 py-2 border-b text-center">Dirección</th>
 									<th className="px-4 py-2 border-b"></th>
 								</tr>
 							</thead>
@@ -120,9 +119,6 @@ export default function WarehouseList() {
 												</td>
 												<td className="px-4 py-2 border-b text-center">
 													{warehouse.name}
-												</td>
-												<td className="px-4 py-2 border-b text-center">
-													{warehouse.id}
 												</td>
 												<td className="px-4 py-2 border-b">
 													<button

--- a/src/test/food/warehouse/warehouseList.test.js
+++ b/src/test/food/warehouse/warehouseList.test.js
@@ -33,6 +33,14 @@ describe('WarehouseList', () => {
 		const elements = await screen.findAllByTestId('warehouse-data')
 		expect(elements).toHaveLength(mockData.length)
 	})
+	test('render warehouses error', async () => {
+		const axiosSpy = jest.spyOn(axios, 'get')
+		axiosSpy.mockRejectedValue(null)
+
+		render(<WarehouseList />)
+		const elements = screen.queryAllByTestId('warehouse-data')
+		expect(elements).toHaveLength(0)
+	})
 	test('update warehouse', async () => {
 		const mockData = [
 			{ id: 1, name: 'name 1' },
@@ -92,7 +100,7 @@ describe('WarehouseList', () => {
 
 		expect(axiosDeleteSpy).toHaveBeenCalled()
 	})
-	test('delete warehouse error', async () => {
+	test('delete warehouse error 404', async () => {
 		const mockData = [
 			{ id: 1, name: 'name 1' },
 			{ id: 2, name: 'name 2' }
@@ -104,6 +112,25 @@ describe('WarehouseList', () => {
 		const axiosDeleteSpy = jest.spyOn(axios, 'delete')
 		axiosSpy.mockResolvedValue({ data: mockData })
 		axiosDeleteSpy.mockRejectedValue({ response: { status: 404 } })
+		render(<WarehouseList />)
+		const elements = await screen.findAllByTestId('warehouse-data')
+		const buttons = elements[0].getElementsByTagName('button')
+		fireEvent.click(buttons[1])
+
+		expect(axiosDeleteSpy).toHaveBeenCalled()
+	})
+	test('delete warehouse error', async () => {
+		const mockData = [
+			{ id: 1, name: 'name 1' },
+			{ id: 2, name: 'name 2' }
+		]
+
+		const confirmSpy = jest.spyOn(window, 'confirm')
+		confirmSpy.mockImplementation(jest.fn(() => true))
+		const axiosSpy = jest.spyOn(axios, 'get')
+		const axiosDeleteSpy = jest.spyOn(axios, 'delete')
+		axiosSpy.mockResolvedValue({ data: mockData })
+		axiosDeleteSpy.mockRejectedValue({ response: { status: 500 } })
 		render(<WarehouseList />)
 		const elements = await screen.findAllByTestId('warehouse-data')
 		const buttons = elements[0].getElementsByTagName('button')

--- a/src/test/food/warehouse/warehouseList.test.js
+++ b/src/test/food/warehouse/warehouseList.test.js
@@ -1,0 +1,182 @@
+/* eslint-disable no-unused-vars */
+import React from 'react'
+/* eslint-enable no-unused-vars */
+import { test, expect, describe, jest } from '@jest/globals'
+import { render, screen, fireEvent } from '@testing-library/react'
+import WarehouseList from '../../../app/food/warehouse/page'
+import axios from 'axios'
+
+jest.mock('next/navigation', () => ({
+	useRouter: () => ({
+		push: jest.fn()
+	}),
+	useSearchParams: () => ({
+		get: jest.fn()
+	}),
+	usePathname: () => ({
+		get: jest.fn()
+	})
+}))
+describe('WarehouseList', () => {
+	jest.mock('axios')
+
+	test('render warehouses', async () => {
+		const mockData = [
+			{ id: 1, name: 'name 1' },
+			{ id: 2, name: 'name 2' }
+		]
+
+		const axiosSpy = jest.spyOn(axios, 'get')
+		axiosSpy.mockResolvedValue({ data: mockData })
+
+		render(<WarehouseList />)
+		const elements = await screen.findAllByTestId('warehouse-data')
+		expect(elements).toHaveLength(mockData.length)
+	})
+	test('update warehouse', async () => {
+		const mockData = [
+			{ id: 1, name: 'name 1' },
+			{ id: 2, name: 'name 2' }
+		]
+
+		const axiosSpy = jest.spyOn(axios, 'get')
+		const axiosPutSpy = jest.spyOn(axios, 'put')
+		axiosSpy.mockResolvedValue({ data: mockData })
+		render(<WarehouseList />)
+		const elements = await screen.findAllByTestId('warehouse-data')
+		const buttons = elements[0].getElementsByTagName('button')
+		fireEvent.click(buttons[0])
+		const updateButton = await screen.findByTestId('create-update-button')
+		fireEvent.click(updateButton)
+
+		expect(axiosPutSpy).toHaveBeenCalled()
+		expect(await screen.getByText(mockData[1].name)).toBeDefined()
+		axiosPutSpy.mockRestore()
+	})
+	test('close update warehouse modal', async () => {
+		const mockData = [
+			{ id: 1, name: 'name 1' },
+			{ id: 2, name: 'name 2' }
+		]
+
+		const axiosSpy = jest.spyOn(axios, 'get')
+		const axiosPutSpy = jest.spyOn(axios, 'put')
+		axiosSpy.mockResolvedValue({ data: mockData })
+		render(<WarehouseList />)
+		const elements = await screen.findAllByTestId('warehouse-data')
+		const buttons = elements[0].getElementsByTagName('button')
+		fireEvent.click(buttons[0])
+		const closeButton = await screen.findByTestId('close-button')
+		fireEvent.click(closeButton)
+
+		expect(axiosPutSpy).toHaveBeenCalledTimes(0)
+		expect(await screen.getByText(mockData[1].name)).toBeDefined()
+		axiosPutSpy.mockRestore()
+	})
+	test('delete warehouse', async () => {
+		const mockData = [
+			{ id: 1, name: 'name 1' },
+			{ id: 2, name: 'name 2' }
+		]
+
+		const confirmSpy = jest.spyOn(window, 'confirm')
+		confirmSpy.mockImplementation(jest.fn(() => true))
+		const axiosSpy = jest.spyOn(axios, 'get')
+		const axiosDeleteSpy = jest.spyOn(axios, 'delete')
+		axiosSpy.mockResolvedValue({ data: mockData })
+		axiosDeleteSpy.mockResolvedValue()
+		render(<WarehouseList />)
+		const elements = await screen.findAllByTestId('warehouse-data')
+		const buttons = elements[0].getElementsByTagName('button')
+		fireEvent.click(buttons[1])
+
+		expect(axiosDeleteSpy).toHaveBeenCalled()
+	})
+	test('delete warehouse error', async () => {
+		const mockData = [
+			{ id: 1, name: 'name 1' },
+			{ id: 2, name: 'name 2' }
+		]
+
+		const confirmSpy = jest.spyOn(window, 'confirm')
+		confirmSpy.mockImplementation(jest.fn(() => true))
+		const axiosSpy = jest.spyOn(axios, 'get')
+		const axiosDeleteSpy = jest.spyOn(axios, 'delete')
+		axiosSpy.mockResolvedValue({ data: mockData })
+		axiosDeleteSpy.mockRejectedValue({ response: { status: 404 } })
+		render(<WarehouseList />)
+		const elements = await screen.findAllByTestId('warehouse-data')
+		const buttons = elements[0].getElementsByTagName('button')
+		fireEvent.click(buttons[1])
+
+		expect(axiosDeleteSpy).toHaveBeenCalled()
+	})
+	test('create warehouse', async () => {
+		const mockData = [
+			{ id: 1, name: 'name 1' },
+			{ id: 2, name: 'name 2' }
+		]
+
+		const axiosSpy = jest.spyOn(axios, 'get')
+		const axiosPostSpy = jest.spyOn(axios, 'post')
+		axiosSpy.mockResolvedValue({ data: mockData })
+		render(<WarehouseList />)
+		const showButton = await screen.findByText('Añadir almacén')
+		fireEvent.click(showButton)
+		const nameInput = await screen.findByTestId('nombre')
+		fireEvent.change(nameInput, { target: { value: 'testTyping' } })
+		expect(await screen.getByText('Nombre:')).toBeDefined()
+		expect(nameInput.value).toBe('testTyping')
+
+		const createButton = await screen.findByTestId('create-update-button')
+		fireEvent.click(createButton)
+		expect(axiosPostSpy).toHaveBeenCalled()
+		axiosPostSpy.mockRestore()
+	})
+	test('create warehouse no name', async () => {
+		const mockData = [
+			{ id: 1, name: 'name 1' },
+			{ id: 2, name: 'name 2' }
+		]
+
+		const axiosSpy = jest.spyOn(axios, 'get')
+		const axiosPostSpy = jest.spyOn(axios, 'post')
+		axiosSpy.mockResolvedValue({ data: mockData })
+		render(<WarehouseList />)
+		const showButton = await screen.findByText('Añadir almacén')
+		fireEvent.click(showButton)
+		const nameInput = await screen.findByTestId('nombre')
+		expect(await screen.getByText('Nombre:')).toBeDefined()
+		expect(nameInput.value).toBe('')
+
+		const createButton = await screen.findByTestId('create-update-button')
+		fireEvent.click(createButton)
+		expect(axiosPostSpy).toHaveBeenCalledTimes(0)
+		axiosPostSpy.mockRestore()
+	})
+	test('create warehouse same name', async () => {
+		const mockData = [
+			{ id: 1, name: 'name 1' },
+			{ id: 2, name: 'name 2' }
+		]
+
+		const axiosSpy = jest.spyOn(axios, 'get')
+		const axiosPostSpy = jest.spyOn(axios, 'post')
+		axiosSpy.mockResolvedValue({ data: mockData })
+		axiosPostSpy.mockRejectedValue({ response: { status: 400 } })
+
+		render(<WarehouseList />)
+		const showButton = await screen.findByText('Añadir almacén')
+		fireEvent.click(showButton)
+
+		const nameInput = await screen.findByTestId('nombre')
+		fireEvent.change(nameInput, { target: { value: 'testTyping' } })
+		expect(await screen.getByText('Nombre:')).toBeDefined()
+		expect(nameInput.value).toBe('testTyping')
+
+		const createButton = await screen.findByTestId('create-update-button')
+		fireEvent.click(createButton)
+		expect(axiosPostSpy).toHaveBeenCalled()
+		axiosPostSpy.mockRestore()
+	})
+})


### PR DESCRIPTION
# Description

A view has been created for the list of warehouses which contains a button to delete the desired warehouse, a modal has also been implemented for the creation.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# Screenshot:
This is the view of the list of warehouses
![image](https://github.com/ISPP-07/frontend-cyc/assets/73199700/41d5b6ea-4095-4663-af0b-cf24a031754f)
Here you can see the form for the creation of a new warehouse.
![image](https://github.com/ISPP-07/frontend-cyc/assets/73199700/d01a5ff5-eb87-4443-8467-fdd4af2d760c)
And this view is what is shown when you press the update button, in this case the store1 was selected and that's why it shows you directly its name.
![image](https://github.com/ISPP-07/frontend-cyc/assets/73199700/5c8596ba-5ceb-4668-8643-6a4445d47a89)
